### PR TITLE
役割分担前の状態をmainに保存

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ git clone [リポジトリURL]
 cp .env.example .env
 ```
 
-※DB 接続情報を手動で以下のように書き換えお願いします！
-DB_CONNECTION=mysql
-DB_HOST=mysql
-DB_PORT=3306
-DB_DATABASE=laravel
-DB_USERNAME=sail
-DB_PASSWORD=password
+# ※DB 接続情報を手動で以下のように書き換えお願いします！
+
+-   DB_CONNECTION=mysql
+-   DB_HOST=mysql
+-   DB_PORT=3306
+-   DB_DATABASE=laravel
+-   DB_USERNAME=sail
+-   DB_PASSWORD=password
 
 5. VS Code でプロジェクトを開く
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ git clone [リポジトリURL]
 cp .env.example .env
 ```
 
+※DB 接続情報を手動で以下のように書き換えお願いします！
+DB_CONNECTION=mysql
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=sail
+DB_PASSWORD=password
+
 5. VS Code でプロジェクトを開く
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "fakerphp/faker": "^1.23",
         "laravel/pail": "^1.1",
         "laravel/pint": "^1.13",
-        "laravel/sail": "^1.26",
+        "laravel/sail": "^1.39",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.1",
         "phpunit/phpunit": "^11.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "626b9e7ddd47fb7eff9aaa53cce0c9ad",
+    "content-hash": "faacb887cddf6c63f8cb02fba947cc48",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
WIndows環境でクローン後にエラーが発生したため、解消のためcomposer.jsonなどを編集しています。
たけうってぃー協力のもと、Mac環境にpullして問題なく動くことが確認できたため
developブランチの内容をmainへ移行します。
developから更に分担した役割ごとにブランチをきって、それぞれdevelopへマージしましょう！